### PR TITLE
fixes use of model-filetypes like .obj

### DIFF
--- a/engine/Shopware/Bundle/MediaBundle/Strategy/Md5Strategy.php
+++ b/engine/Shopware/Bundle/MediaBundle/Strategy/Md5Strategy.php
@@ -45,7 +45,7 @@ class Md5Strategy implements StrategyInterface
         $path = str_replace('//', '/', $path);
 
         // remove everything before /media/...
-        preg_match("/.*((media\/(?:archive|image|music|pdf|temp|unknown|video|vector)(?:\/thumbnail)?).*\/((.+)\.(.+)))/", $path, $matches);
+        preg_match("/.*((media\/(?:archive|image|model|music|pdf|temp|unknown|video|vector)(?:\/thumbnail)?).*\/((.+)\.(.+)))/", $path, $matches);
 
         if (!empty($matches)) {
             return $matches[2] . '/' . $matches[3];
@@ -99,7 +99,7 @@ class Md5Strategy implements StrategyInterface
             return false;
         }
 
-        return (bool) preg_match("/.*(media\/(?:archive|image|music|pdf|temp|unknown|video|vector)(?:\/thumbnail)?\/(?:([0-9a-g]{2}\/[0-9a-g]{2}\/[0-9a-g]{2}\/))((.+)\.(.+)))/", $path);
+        return (bool) preg_match("/.*(media\/(?:archive|image|model|music|pdf|temp|unknown|video|vector)(?:\/thumbnail)?\/(?:([0-9a-g]{2}\/[0-9a-g]{2}\/[0-9a-g]{2}\/))((.+)\.(.+)))/", $path);
     }
 
     /**
@@ -125,7 +125,7 @@ class Md5Strategy implements StrategyInterface
      */
     private function substringPath($path)
     {
-        preg_match("/(media\/(?:archive|image|music|pdf|temp|unknown|video|vector)(?:\/thumbnail)?\/.*)/", $path, $matches);
+        preg_match("/(media\/(?:archive|image|model|music|pdf|temp|unknown|video|vector)(?:\/thumbnail)?\/.*)/", $path, $matches);
 
         return empty($matches) ? null : $matches[0];
     }

--- a/engine/Shopware/Bundle/MediaBundle/Strategy/PlainStrategy.php
+++ b/engine/Shopware/Bundle/MediaBundle/Strategy/PlainStrategy.php
@@ -60,7 +60,7 @@ class PlainStrategy implements StrategyInterface
             return '';
         }
 
-        preg_match('/.*((media\/(?:archive|image|music|pdf|temp|unknown|video|vector)(?:\/thumbnail)?).*\/((.+)\.(.+)))/', $path, $matches);
+        preg_match('/.*((media\/(?:archive|image|model|music|pdf|temp|unknown|video|vector)(?:\/thumbnail)?).*\/((.+)\.(.+)))/', $path, $matches);
 
         if (!empty($matches)) {
             $path = $matches[2] . '/' . $matches[3];
@@ -79,6 +79,6 @@ class PlainStrategy implements StrategyInterface
      */
     public function isEncoded($path)
     {
-        return (bool) preg_match('/.*((media\/(?:archive|image|music|pdf|temp|unknown|video|vector)(?:\/thumbnail)?).*\/((.+)\.(.+)))/', $path);
+        return (bool) preg_match('/.*((media\/(?:archive|image|model|music|pdf|temp|unknown|video|vector)(?:\/thumbnail)?).*\/((.+)\.(.+)))/', $path);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When using an .obj-file as download resource of an article, the file won't be correctly normalized, since it is in the "model" folder.

### 2. What does this change do, exactly?
After adding "model" to the nortmalize function the link will be correkt 
(before: http:/localhost/..., after: media/...) (Note the wrong http:// in the wrong behaviour)

### 3. Describe each step to reproduce the issue or behaviour.
Add an .obj as download to an article, the download-link isn't working

Before:
![auswahl_007](https://user-images.githubusercontent.com/10058559/41529599-f6b862bc-72ed-11e8-8e23-24b79d1b082a.jpg)


After:
![auswahl_008](https://user-images.githubusercontent.com/10058559/41529586-ee4e6d2e-72ed-11e8-84f9-08ef2807063d.jpg)


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.